### PR TITLE
extracting packages & calculating checksums

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -2,7 +2,7 @@
 bears = LineCountBear, FilenameBear
 files = **.py, **.yaml, **.rst
 file_naming_convention = snake
-ignore = **/__pycache__/**, **/__pycache__, __pycache__, __pycache__/**, **/*.pyc, *.pyc
+ignore = **/__pycache__/**, **/__pycache__, __pycache__, __pycache__/**, **/*.pyc, *.pyc, openshift/*.yaml
 max_lines_per_file = 1000
 max_line_length = 120
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-thoth-digests-fetcher
+thoth-package-analyzer
 ---------------------
 
 A tool for gathering digests of packages and files present inside packages for various ecosystems.

--- a/app.sh
+++ b/app.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+#
+# This script is run by OpenShift's s2i. Here we guarantee that we run desired
+# sub-command based on env-variables configuration.
+#
+
+case $THOTH_PACKAGE_ANALYZER_SUBCOMMAND in
+	'python')
+		exec /opt/app-root/bin/python3 thoth-package-analyzer python
+		;;
+	*)
+		echo "Application configuration error - no analyzer subcommand specified." >&2
+		exit 1
+		;;
+esac

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: package-analyzer-buildconfig
+  annotations:
+    description: This is Thoth Core - Package Analyzer BuildConfig
+    openshift.io/display-name: "Thoth: Package Analyzer BuildConfig"
+    version: 0.3.0
+    tags: poc,thoth,ai-stacks,package-analyzer
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: |-
+      This template defines resources needed to deploy Thoth Package
+      Analyzer as a Proof-of-Concept to OpenShift.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+  labels:
+    template: package-analyzer-buildconfig
+    app: thoth
+    component: package-analyzer
+
+objects:
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: package-analyzer
+      labels:
+        app: thoth
+        component: package-analyzer
+    spec:
+      resources:
+        requests:
+          cpu: 2
+          memory: 768Mi
+        limits:
+          cpu: 2
+          memory: 1024Mi
+      output:
+        to:
+          kind: ImageStreamTag
+          name: "package-analyzer:${IMAGE_STREAM_TAG}"
+      source:
+        type: Git
+        git:
+          uri: "${GITHUB_URL}"
+          ref: "${GITHUB_REF}"
+      strategy:
+        type: Source
+        sourceStrategy:
+          from:
+            kind: ImageStreamTag
+            name: python-36-centos7:latest
+          env:
+            - name: ENABLE_PIPENV
+              value: "1"
+      triggers:
+        - imageChange: {}
+          type: ImageChange
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
+
+parameters:
+  - description: Name of the github repository
+    displayName: Git Repository
+    required: true
+    name: GITHUB_URL
+    value: 'https://github.com/thoth-station/package-analyzer'
+
+  - description: Git reference to be used
+    displayName: Git Reference
+    required: true
+    name: GITHUB_REF
+    value: 'master'
+
+  - description: Tag of the output ImageStream the resulting container image should go to
+    displayName: ImageStream Tag
+    required: true
+    name: IMAGE_STREAM_TAG
+    value: 'latest'

--- a/openshift/imageStream-template.yaml
+++ b/openshift/imageStream-template.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: package-analyzer-imagestream
+  annotations:
+    description: This is Thoth Core - Package Analyzer ImageStream
+    openshift.io/display-name: "Thoth: Package Analyzer ImageStream"
+    version: 0.1.3
+    tags: poc,thoth,ai-stacks,package-analyzer
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: |-
+      This template defines resources needed to deploy Thoth Package
+      Analyzer as a Proof-of-Concept to OpenShift.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+  labels:
+    template: package-analyzer-imagestream
+    app: thoth
+    component: package-analyzer
+
+objects:
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: package-analyzer
+      labels:
+        app: thoth
+        component: package-analyzer
+    spec:
+      name: latest
+      lookupPolicy:
+        local: true

--- a/openshift/job-template.yaml
+++ b/openshift/job-template.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: package-analyzer
+  annotations:
+    description: "Thoth: Package Analyzer Template"
+    openshift.io/display-name: "Thoth: Package Analyzer Template"
+    version: 0.4.0
+    tags: thoth,ai-stacks,aistacks,package-analyzer
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to run package analyzer in Thoth to OpenShift, it is used
+      to create new OpenShift Jobs running the package analyzer.
+    template.openshift.io/provider-display-name: Red Hat, Inc.
+  labels:
+    template: package-analyzer
+    app: thoth
+    component: package-analyzer
+
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: package-analyzer
+      labels:
+        app: thoth
+        component: package-analyzer
+        operator: graph-sync
+        task: package-analyzer
+        mark: cleanup
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: thoth
+            component: package-analyzer
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          containers:
+            - name: package-analyzer
+              image: "${THOTH_REGISTRY}/${IMAGE_STREAM_PROJECT_NAME}/package-analyzer"
+              livenessProbe:
+                # Give package analyzer 30 minutes to compute results, kill it if it was not able result anything.
+                tcpSocket:
+                  port: 80
+                initialDelaySeconds: 1800
+                failureThreshold: 1
+                periodSeconds: 10
+              env:
+                - name: THOTH_PACKAGE_ANALYZER_SUBCOMMAND
+                  value: "python"
+                - name: THOTH_PACKAGE_ANALYZER_DEBUG
+                  value: "${THOTH_PACKAGE_ANALYZER_DEBUG}"
+                - name: THOTH_PACKAGE_ANALYZER_PACKAGE_NAME
+                  value: "${THOTH_PACKAGE_ANALYZER_PACKAGE_NAME}"
+                - name: THOTH_PACKAGE_ANALYZER_PACKAGE_VERSION
+                  value: "${THOTH_PACKAGE_ANALYZER_PACKAGE_VERSION}"
+                - name: THOTH_PACKAGE_ANALYZER_INDEX_URL
+                  value: "${THOTH_PACKAGE_ANALYZER_INDEX_URL}"
+                - name: THOTH_PACKAGE_ANALYZER_OUTPUT
+                  value: "${THOTH_PACKAGE_ANALYZER_OUTPUT}"
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      key: sentry-dsn
+                      name: thoth
+              resources:
+                limits:
+                  memory: '2Gi'
+                  cpu: '1000m'
+                requests:
+                  memory: '2Gi'
+                  cpu: '1000m'
+
+parameters:
+  - name: THOTH_PACKAGE_ANALYZER_JOB_ID
+    description: A job id for package analyzer job.
+    displayName: Job identifier
+    required: true
+  - name: THOTH_PACKAGE_ANALYZER_DEBUG
+    displayName: Package Analyzer Verbose
+    description: Run the given package analyzer in a verbose mode so developers can debug
+    required: false
+    value: "false"
+  - name: THOTH_PACKAGE_ANALYZER_PACKAGE_NAME
+    displayName: Package name
+    description: Package name which should be analyzed.
+    required: true
+  - name: THOTH_PACKAGE_ANALYZER_PACKAGE_VERSION
+    displayName: Package version
+    description: Package version which should be analyzed.
+    required: true
+  - name: THOTH_PACKAGE_ANALYZER_INDEX_URL
+    displayName: Python package indexes
+    description: A comma separated list of Python package indexes (package sources) to analyze packages from.
+    required: true
+    value: "https://pypi.org/simple"
+  - name: THOTH_REGISTRY
+    description: Registry server from where Image is to be pulled
+    displayName: Registry
+    required: true
+    value: "docker-registry.default.svc:5000"
+  - name: IMAGE_STREAM_PROJECT_NAME
+    description: Project where ImageStream is present
+    displayName: ImageStream Project
+    required: true
+    value: "thoth-test-core"
+  - name: THOTH_PACKAGE_ANALYZER_OUTPUT
+    description: Remote where results should be send to
+    displayName: Analyzer output
+    required: true

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_install_requires():
 
 
 def get_version():
-    with open(os.path.join('thoth', 'digests_fetcher', '__init__.py')) as f:
+    with open(os.path.join('thoth', 'package_analyzer', '__init__.py')) as f:
         content = f.readlines()
 
     for line in content:
@@ -45,16 +45,16 @@ class Test(TestCommand):
 
 
 setup(
-    name='thoth-digests-fetcher',
+    name='thoth-package-analyzer',
     version=get_version(),
     description='Gather digests for artifacts in Python ecosystem.',
     long_description=read('README.rst'),
     author='Fridolin Pokorny',
     author_email='fridolin@redhat.com',
     license='GPLv3+',
-    packages=['thoth.digests_fetcher', 'thoth.digests_fetcher.python'],
+    packages=['thoth.package_analyzer', 'thoth.package_analyzer.python'],
     entry_points={
-        'console_scripts': ['thoth-digests-fetcher=thoth.digests_fetcher.cli:cli']
+        'console_scripts': ['thoth-package-analyzer=thoth.package_analyzer.cli:cli']
     },
     zip_safe=False,
     install_requires=get_install_requires(),

--- a/thoth-digests-fetcher
+++ b/thoth-digests-fetcher
@@ -1,1 +1,0 @@
-thoth/digests_fetcher/cli.py

--- a/thoth-package-analyzer
+++ b/thoth-package-analyzer
@@ -1,0 +1,1 @@
+thoth/package_analyzer/cli.py

--- a/thoth/package_analyzer/__init__.py
+++ b/thoth/package_analyzer/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# thoth-digests-fetcher
-# Copyright(C) 2019 ???
+# thoth-package-analyzer
+# Copyright(C) 2019 Fridolin Pokorny
 #
 # This program is free software: you can redistribute it and / or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +15,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Fetch digests for packages from Python ecosystem."""
+"""A tool for gathering digests of packages and files present inside packages."""
 
-from .fetch import PythonDigestsFetcher
+
+__title__ = "thoth-package-analyzer"
+__version__ = "0.1.0"
+
+
+from .python import PythonDigestsFetcher

--- a/thoth/package_analyzer/base.py
+++ b/thoth/package_analyzer/base.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# thoth-digests-fetcher
+# thoth-package-analyzer
 # Copyright(C) 2019 Fridolin Pokorny
 #
 # This program is free software: you can redistribute it and / or modify

--- a/thoth/package_analyzer/cli.py
+++ b/thoth/package_analyzer/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# thoth-digests-fetcher
-# Copyright(C) 2019 Fridolin Pokorny
+# thoth-package-analyzer
+# Copyright(C) 2019 Fridolin Pokorny, Bissenbay Dauletbayev
 #
 # This program is free software: you can redistribute it and / or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,16 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""A command line interface for Python digests fetcher used in project Thoth."""
+"""A command line interface for Python package analyzer used in project Thoth."""
 
 import logging
 
 import click
 from thoth.common import init_logging
 from thoth.analyzer import print_command_result
-from thoth.digests_fetcher import __version__ as analyzer_version
-from thoth.digests_fetcher import __title__ as analyzer_name
-from thoth.digests_fetcher.python import PythonDigestsFetcher
+from thoth.package_analyzer import __version__ as analyzer_version
+from thoth.package_analyzer import __title__ as analyzer_name
+from thoth.package_analyzer.python import PythonDigestsFetcher
 
 
 init_logging()
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _print_version(ctx, _, value):
-    """Print digests-fetcher version and exit."""
+    """Print package-analyzer version and exit."""
     if not value or ctx.resilient_parsing:
         return
     click.echo(analyzer_version)
@@ -42,7 +42,11 @@ def _print_version(ctx, _, value):
 @click.group()
 @click.pass_context
 @click.option(
-    "-v", "--verbose", is_flag=True, envvar="THOTH_DIGESTS_FETCHER_DEBUG", help="Be verbose about what's going on."
+    "-v",
+    "--verbose",
+    is_flag=True,
+    envvar="THOTH_PACKAGE_ANALYZER_DEBUG",
+    help="Be verbose about what's going on.",
 )
 @click.option(
     "--version",
@@ -50,12 +54,12 @@ def _print_version(ctx, _, value):
     is_eager=True,
     callback=_print_version,
     expose_value=False,
-    help="Print digests fetcher version and exit.",
+    help="Print package analyzer version and exit.",
 )
 def cli(ctx=None, verbose=False):
-    """Thoth digests-fetcher command line interface."""
+    """Thoth package-analyzer command line interface."""
     if ctx:
-        ctx.auto_envvar_prefix = "THOTH_DIGESTS_FETCHER"
+        ctx.auto_envvar_prefix = "THOTH_PACKAGE_ANALYZER"
 
     if verbose:
         _LOGGER.setLevel(logging.DEBUG)
@@ -71,16 +75,16 @@ def cli(ctx=None, verbose=False):
     "-p",
     type=str,
     required=True,
-    envvar="THOTH_DIGESTS_FETCHER_PACKAGE_NAME",
-    help="Package name for which digests should be fetcher.",
+    envvar="THOTH_PACKAGE_ANALYZER_PACKAGE_NAME",
+    help="Package name for which digests should be fetched.",
 )
 @click.option(
     "--package-version",
     "-v",
     type=str,
     required=True,
-    envvar="THOTH_DIGESTS_FETCHER_PACKAGE_VERSION",
-    help="Package name for which digests should be fetcher.",
+    envvar="THOTH_PACKAGE_ANALYZER_PACKAGE_VERSION",
+    help="Package version for which digests should be fetched.",
 )
 @click.option(
     "--index-url",
@@ -89,10 +93,18 @@ def cli(ctx=None, verbose=False):
     required=False,
     default="https://pypi.org/simple",
     show_default=True,
-    envvar="THOTH_DIGESTS_FETCHER_INDEX_URL",
+    envvar="THOTH_PACKAGE_ANALYZER_INDEX_URL",
     help="URL of the Python package index to pull the package from.",
 )
 @click.option("--no-pretty", "-P", is_flag=True, help="Do not print results nicely.")
+@click.option(
+    "--output",
+    "-o",
+    type=str,
+    envvar="THOTH_PACKAGE_ANALYZER_OUTPUT",
+    default=None,
+    help="Output file or remote API to print results to, in case of URL a POST request is issued.",
+)
 def python(
     click_ctx,
     package_name: str,
@@ -111,7 +123,7 @@ def python(
         result,
         analyzer=analyzer_name,
         analyzer_version=analyzer_version,
-        output=output,
+        output=output or "-",
         pretty=not no_pretty,
     )
 

--- a/thoth/package_analyzer/exceptions.py
+++ b/thoth/package_analyzer/exceptions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# thoth-digests-fetcher
+# thoth-package-analyzer
 # Copyright(C) 2019 Fridolin Pokorny
 #
 # This program is free software: you can redistribute it and / or modify
@@ -15,8 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Exceptions used inside and outside of digests-fetcher."""
+"""Exceptions used inside and outside of package-analyzer."""
 
 
 class DigestsFetcherException(Exception):
-    """A base class for exception hierarchy used in digests fetcher."""
+    """A base class for exception hierarchy used in package analyzer."""

--- a/thoth/package_analyzer/python/__init__.py
+++ b/thoth/package_analyzer/python/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# thoth-digests-fetcher
-# Copyright(C) 2019 Fridolin Pokorny
+# thoth-package-analyzer
+# Copyright(C) 2019 Fridolin Pokorny, Bissenbay Dauletbayev
 #
 # This program is free software: you can redistribute it and / or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,11 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""A tool for gathering digests of packages and files present inside packages."""
+"""Fetch digests for packages from Python ecosystem."""
 
-
-__title__ = "thoth-digests-fetcher"
-__version__ = "0.1.0"
-
-
-from .python import PythonDigestsFetcher
+from .fetch import PythonDigestsFetcher

--- a/thoth/package_analyzer/python/fetch.py
+++ b/thoth/package_analyzer/python/fetch.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# thoth-digests-fetcher
-# Copyright(C) 2019 ???
+# thoth-package-analyzer
+# Copyright(C) 2019 Fridolin Pokorny, Bissenbay Dauletbayev
 #
 # This program is free software: you can redistribute it and / or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
 import logging
 
 from thoth.python import Source
-from thoth.digests_fetcher.base import FetcherBase
+from thoth.package_analyzer.base import FetcherBase
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class PythonDigestsFetcher(FetcherBase):
     """Fetch digests of python package artifacts and all the files present in artifacts."""
 
     def __init__(self, index_url: str):
-        """Initialize Python digests fetcher."""
+        """Initialize Python package analyzer."""
         self.source = Source(index_url)
 
     def fetch(self, package_name: str, package_version: str) -> dict:
@@ -38,10 +38,11 @@ class PythonDigestsFetcher(FetcherBase):
             "Fetching digests for package %r in version %r from %r", package_name, package_version, self.source.url
         )
 
-        # TODO: implement the real stuff
+        files = self.source.get_package_hashes(package_name, package_version, True)
+
         return {
             "package_name": package_name,
             "package_version": package_version,
             "index_url": self.source.url,
-            "files": [],
+            "files": files,
         }


### PR DESCRIPTION
Depends-On: #5 

Examples to run:
[AI CoE] ./thoth-digests-fetcher python -p tensorflow -v 1.10 -i https://pypi.thoth-station.ninja
[Pypi] ./thoth-digests-fetcher python -p tensorflow -v 1.10.0 -i https://pypi.org/simple

So, as we have different index servers, the approach to retrieve whl files from them is different. 

Pypi
There are a bunch of ways to approach. 
The very initial thought was to send a GET request to https://pypi.org/simple/tensorflow/ and parse the HTML Page with something like BeautifulSoup.
Second, I find out this API https://pypi.org/pypi/tensorflow/json which serves JSON response, but we cannot send the version number
I chose the second approach. Inside “releases” we can get JSON object specifying “version” and every object has“url” which is the link to download a .whl file

AI CoE
This https://tensorflow.pypi.thoth-station.ninja/index/ is a HTML file which contains a list of os folders -> version folders -> cpu related folders -> actual .whl files. 
First, very intuitive way was just to create static links https://tensorflow.pypi.thoth-station.ninja/index/centos7/1.1.0/simple/tensorflow/ by changing only package name and version. Send a GET request, then parse the HTML page to find href attributes which leads to downloadable .whl files. But, the problem I thought here might be that maybe in the future if a new version of fedora comes, then that needs to be changed on the code which is not good. 
Second idea was to use something like scraper or BeautifulSoup to parse HTML page ajd recursively find downloadable links.
However, after talking to @harshad16, I realized that .whl files which we see when requesting https://tensorflow.pypi.thoth-station.ninja/index/ are actually residing on Github and there is like an API https://api.github.com/repos/AICoE/tensorflow-wheels/releases which gives a list of objects which contains links to download .whl files.

TO BE NOTED:
Pypi.org
When it comes to the standard index, they can be downloaded into one folder directory because the names of files are unique

AI CoE
In this case, files cannot be downloaded into one directory because files might have same names