### PR TITLE
Fix syntax error

### DIFF
--- a/thoth/package_analyzer/cli.py
+++ b/thoth/package_analyzer/cli.py
@@ -120,7 +120,7 @@ def python(
     index_url: str = None,
     no_pretty: bool = True,
     output: str = None,
-    dry_run: bool,
+    dry_run: bool = False,
 ):
     """Fetch digests for packages in Python ecosystem."""
     python_fetcher = PythonDigestsFetcher(index_url)


### PR DESCRIPTION
```
File "./thoth-package-analyzer", line 117
    click_ctx,
    ^
SyntaxError: non-default argument follows default argument
```