### PR TITLE
Disable setup.py processing in s2i builds

### DIFF
--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -56,6 +56,8 @@ objects:
               value: "1"
             - name: "THOTH_DRY_RUN"
               value: "1"
+            - name: "DISABLE_SETUP_PY_PROCESSING"
+              value: "1"
             - name: "THOTH_ADVISE"
               value: ${THOTH_ADVISE}
             - name: "THAMOS_VERBOSE"


### PR DESCRIPTION
See https://github.com/sclorg/s2i-python-container/tree/master/3.6#environment-variables for more info.